### PR TITLE
feat: enable live process monitoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,10 @@ ENV NON_LOCAL_TRAFFIC=true
 ENV DD_APM_ENABLED=true
 ENV DD_APM_NON_LOCAL_TRAFFIC=true
 ENV DD_LOGS_ENABLED=true
-ENV DD_PROFILING_ENABLED=true
-
+ENV DD_PROCESS_AGENT_ENABLED=true
 ENV DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+
+VOLUME /etc/passwd
 
 COPY postgres.d/conf.yaml /etc/datadog-agent/conf.d/postgres.d/conf.yaml
 


### PR DESCRIPTION
Enabling live process monitoring for the agent, per https://docs.datadoghq.com/infrastructure/process/?tab=docker#installation

Also removed `DD_PROFILING_ENABLED` which is meant to be an [env var in the app being traced](https://docs.datadoghq.com/profiler/enabling/nodejs/?tab=environmentvariables), not the agent (the agent logs an error: `Unknown environment variable: DD_PROFILING_ENABLED`)